### PR TITLE
Use StreamExecutionEnvironment argument

### DIFF
--- a/src/main/java/io/peleg/JobRunner.java
+++ b/src/main/java/io/peleg/JobRunner.java
@@ -13,8 +13,7 @@ public class JobRunner<T> {
         this.sourceFunction = sourceFunction;
     }
 
-    public void run(StreamExecutionEnvironment environment) throws Exception {
-        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    public void run(StreamExecutionEnvironment env) throws Exception {
 
         env.enableCheckpointing(12000L, CheckpointingMode.EXACTLY_ONCE);
 


### PR DESCRIPTION
Otherwise the execution config settings made by the avro/pojo jobs have no effect.